### PR TITLE
remove missing version in worker containerfile

### DIFF
--- a/Containerfile.slurm-worker
+++ b/Containerfile.slurm-worker
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=vhpc-base:${VERSION}
+ARG BASE_IMAGE=vhpc-base:latest
 FROM ${BASE_IMAGE}
 
 # Install additional runtime dependencies


### PR DESCRIPTION
This seems to be the solution to #31 with the least amount of changes: remove the VERSION variable (BASE_IMAGAE version) from the worker containerfile - which had no default value, nor it was used in the headnode containerfile or in the composefile.